### PR TITLE
change return format handling

### DIFF
--- a/src/python/DataDatasetLocked.py
+++ b/src/python/DataDatasetLocked.py
@@ -11,7 +11,7 @@ class DatasetLocked(RESTEntity):
     """Validate request input data."""
     pass
 
-  @restcall
+  @restcall(formats=[('application/json', JSONFormat()), ('application/xml', XMLFormat())])
   @tools.expires(secs=300)
   def get(self):
     """Retrieve list of locked datasets
@@ -28,4 +28,4 @@ class DatasetLocked(RESTEntity):
       if result[0]:
         datasets.append(result[0])
 
-    return json.dumps(sorted(datasets))
+    return sorted(datasets)

--- a/src/python/DataExpressConfig.py
+++ b/src/python/DataExpressConfig.py
@@ -13,7 +13,7 @@ class ExpressConfig(RESTEntity):
     validate_str('stream', param, safe, RX_STREAM, optional = True)
 
 
-  @restcall
+  @restcall(formats=[('application/json', JSONFormat()), ('application/xml', XMLFormat())])
   @tools.expires(secs=300)
   def get(self,run, stream):
     """Retrieve Express configuration for a specific run (and stream)
@@ -63,4 +63,4 @@ class ExpressConfig(RESTEntity):
                    "scenario" : scenario }
         configs.append(config)
 
-    return json.dumps(configs)
+    return configs

--- a/src/python/DataFirstConditionSafeRun.py
+++ b/src/python/DataFirstConditionSafeRun.py
@@ -11,7 +11,7 @@ class FirstConditionSafeRun(RESTEntity):
   def validate(self, apiobj, method, api, param, safe):
     """Validate request input data. In this case there is no input data"""
 
-  @restcall
+  @restcall(formats=[('application/json', JSONFormat()), ('application/xml', XMLFormat())])
   @tools.expires(secs=300)
   def get(self):
     """Latest run which has not released PromptReco yet
@@ -34,4 +34,4 @@ class FirstConditionSafeRun(RESTEntity):
 
     c, _ = self.api.execute(sql)
 
-    return json.dumps(c.fetchall()[0][0])
+    return c.fetchall()[0][0]

--- a/src/python/DataHello.py
+++ b/src/python/DataHello.py
@@ -10,7 +10,7 @@ class Hello(RESTEntity):
     """Validate request input data."""
     pass
 
-  @restcall
+  @restcall(formats=[('application/json', JSONFormat()), ('application/xml', XMLFormat())])
   @tools.expires(secs=-1)
   def get(self):
     """Hello world api call.
@@ -20,4 +20,4 @@ class Hello(RESTEntity):
 
     :returns: world"""
 
-    return json.dumps("world")
+    return "world"

--- a/src/python/DataRecoConfig.py
+++ b/src/python/DataRecoConfig.py
@@ -12,7 +12,7 @@ class RecoConfig(RESTEntity):
     validate_str('run', param, safe, RX_RUN, optional = True)
     validate_str('primary_dataset', param, safe, RX_PRIMARY_DATASET, optional = True)
 
-  @restcall
+  @restcall(formats=[('application/json', JSONFormat()), ('application/xml', XMLFormat())])
   @tools.expires(secs=300)
   def get(self,run, primary_dataset):
     """Retrieve Reco configuration for a specific run (and primary dataset)
@@ -58,4 +58,4 @@ class RecoConfig(RESTEntity):
                    "scenario" : scenario }
         configs.append(config)
 
-    return json.dumps(configs)
+    return configs

--- a/src/python/DataRunStreamDone.py
+++ b/src/python/DataRunStreamDone.py
@@ -13,7 +13,7 @@ class RunStreamDone(RESTEntity):
     validate_str('stream', param, safe, RX_STREAM, optional = False)
 
 
-  @restcall
+  @restcall(formats=[('application/json', JSONFormat()), ('application/xml', XMLFormat())])
   @tools.expires(secs=300)
   def get(self,run, stream):
     """Check run/stream processing status
@@ -29,4 +29,4 @@ class RunStreamDone(RESTEntity):
 
     c, _ = self.api.execute(sql, run = run, stream = stream)
 
-    return json.dumps(c.fetchall()[0][0] == 1)
+    return (c.fetchall()[0][0] == 1)


### PR DESCRIPTION
Let the REST layer handle the conversion to json or xml based on what is requested (and don't convert to json in our methods directly).