### PR TITLE
switch from int to str in return

### DIFF
--- a/src/python/DataFirstConditionSafeRun.py
+++ b/src/python/DataFirstConditionSafeRun.py
@@ -34,4 +34,4 @@ class FirstConditionSafeRun(RESTEntity):
 
     c, _ = self.api.execute(sql)
 
-    return c.fetchall()[0][0]
+    return str(c.fetchall()[0][0])


### PR DESCRIPTION
The REST API formatting code can't handle ints, therefore switch the firstconditionsafe return from int to str.