### PR TITLE
Add support of nanoaod in DataRecoConfig.py and add nanoaod column to…

### DIFF
--- a/etc/OracleSchema.sql
+++ b/etc/OracleSchema.sql
@@ -30,6 +30,7 @@ CREATE TABLE reco_config (
   write_dqm int default 0 not null,
   write_aod int default 0 not null,
   write_miniaod int default 0 not null,
+  write_nanoaod int default 0 not null,
   alca_skim varchar2(700),
   physics_skim varchar2(700),
   dqm_seq varchar2(700),

--- a/src/python/DataRecoConfig.py
+++ b/src/python/DataRecoConfig.py
@@ -38,7 +38,8 @@ class RecoConfig(RESTEntity):
                     reco_config.write_reco,
                     reco_config.write_dqm,
                     reco_config.write_aod,
-                    reco_config.write_miniaod
+                    reco_config.write_miniaod,
+                    reco_config.write_nanoaod
              FROM reco_config
              WHERE %s %s"""
 
@@ -53,7 +54,7 @@ class RecoConfig(RESTEntity):
     for result in c.fetchall():
 
         (run, primds, cmssw, scram_arch, alca_skim, physics_skim, dqm_seq,
-         global_tag, scenario, multicore, write_reco, write_dqm, write_aod, write_miniaod) = result
+         global_tag, scenario, multicore, write_reco, write_dqm, write_aod, write_miniaod, write_nanoaod) = result
 
         config = { "run" : run,
                    "primary_dataset" : primds,
@@ -68,7 +69,8 @@ class RecoConfig(RESTEntity):
                    "write_reco": bool(write_reco),
                    "write_dqm" : bool(write_dqm),
                    "write_aod" : bool(write_aod),
-                   "write_miniaod" : bool(write_miniaod) }
+                   "write_miniaod" : bool(write_miniaod),
+                   "write_nanoaod" : bool(write_nanoaod) }
         configs.append(config)
 
     return configs


### PR DESCRIPTION
The change in the DataRecoConfig file has been tested in the test pod. With this change it is possible to see write_nanoaod setup in reco configuration in the Tier0 API for RecoConfig. 

