### PR TITLE
Primary dataset config history API entry

### DIFF
--- a/etc/OracleSchema.sql
+++ b/etc/OracleSchema.sql
@@ -73,6 +73,14 @@ CREATE TABLE promptreco_status (
 );
 INSERT INTO promptreco_status (status, change_time) VALUES (1, CURRENT_TIMESTAMP);
 
+CREATE TABLE skipped_streamers (
+  run int not null,
+  stream varchar2(255) not null,
+  lumi int not null,
+  events int not null,
+  primary key (run, stream, lumi)
+) ORGANIZATION INDEX;
+
 CREATE TABLE FILE_TRANSFER_STATUS_OFFLINE (
   P5_FILEID               NUMBER(27)     NOT NULL,
   FILENAME                VARCHAR2(1000) NOT NULL,

--- a/etc/OracleSchema.sql
+++ b/etc/OracleSchema.sql
@@ -81,6 +81,18 @@ CREATE TABLE skipped_streamers (
   primary key (run, stream, lumi)
 ) ORGANIZATION INDEX;
 
+CREATE TABLE primary_dataset_config (
+  primds varchar2(255) not null,
+  acq_era varchar2(255) not null,
+  min_run int not null,
+  max_run int not null,
+  cmssw varchar2(255) not null,
+  global_tag varchar2(50) not null,
+  physics_skim varchar2(700),
+  dqm_seq varchar2(700),
+  primary key (primds)
+) ORGANIZATION INDEX;
+
 CREATE TABLE FILE_TRANSFER_STATUS_OFFLINE (
   P5_FILEID               NUMBER(27)     NOT NULL,
   FILENAME                VARCHAR2(1000) NOT NULL,

--- a/src/python/Data.py
+++ b/src/python/Data.py
@@ -11,6 +11,7 @@ from T0WmaDataSvc.DataPromptRecoStatus import *
 from T0WmaDataSvc.DataDatasetLocked import *
 from T0WmaDataSvc.DataRepackStats import *
 from T0WmaDataSvc.DataRunStreamSkippedLumis import *
+from T0WmaDataSvc.DataPrimaryDatasetConfig.py import *
 
 
 class Data(DatabaseRESTApi):

--- a/src/python/Data.py
+++ b/src/python/Data.py
@@ -10,6 +10,8 @@ from T0WmaDataSvc.DataRunDatasetDone import *
 from T0WmaDataSvc.DataPromptRecoStatus import *
 from T0WmaDataSvc.DataDatasetLocked import *
 from T0WmaDataSvc.DataRepackStats import *
+from T0WmaDataSvc.DataRunStreamSkippedLumis import *
+
 
 class Data(DatabaseRESTApi):
   """Server object for REST data access API."""
@@ -31,5 +33,6 @@ class Data(DatabaseRESTApi):
                 "run_dataset_done": RunDatasetDone(app,self, config, mount),
                 "dataset_locked": DatasetLocked(app, self, config, mount),
                 "promptreco_status": PromptRecoStatus(app, self, config, mount),
-                "repack_stats": RepackStats(app, self, config, mount)
+                "repack_stats": RepackStats(app, self, config, mount),
+                "skipped_streamers": RunStreamSkippedLumis(app, self, config, mount)
                 })

--- a/src/python/Data.py
+++ b/src/python/Data.py
@@ -11,7 +11,7 @@ from T0WmaDataSvc.DataPromptRecoStatus import *
 from T0WmaDataSvc.DataDatasetLocked import *
 from T0WmaDataSvc.DataRepackStats import *
 from T0WmaDataSvc.DataRunStreamSkippedLumis import *
-from T0WmaDataSvc.DataPrimaryDatasetConfig.py import *
+from T0WmaDataSvc.DataPrimaryDatasetConfig import *
 
 
 class Data(DatabaseRESTApi):

--- a/src/python/DataPrimaryDatasetConfig.py
+++ b/src/python/DataPrimaryDatasetConfig.py
@@ -20,7 +20,7 @@ class RecoConfig(RESTEntity):
     :returns: PrimaryDataset, Acquisition era, minimum run, maximum run, CMSSW, PhysicsSkim, DqmSeq, GlobalTag"""
 
     sql = """
-            SELECT reco_config.primds, run_config.acq_era, MIN(run_config.run) min_run, MAX(run_config.run) max_run, reco_config.cmssw, reco_config.global_tag, reco_config.physics_skim, reco_config.dqm_seq
+            SELECT reco_config.primds primds, run_config.acq_era acq_era, MIN(run_config.run) min_run, MAX(run_config.run) max_run, reco_config.cmssw cmssw, reco_config.global_tag global_tag, reco_config.physics_skim physics_skim, reco_config.dqm_seq dqm_seq
             FROM reco_config
             JOIN run_config ON run_config.run = reco_config.run
 
@@ -39,22 +39,22 @@ class RecoConfig(RESTEntity):
 
     sql += sql_group
     sql += sql_order
-
+    sql += "INTO primary_dataset_config"
     c, _ = self.api.execute(sql, binds)
     results=c.fetchall()
 
   
     configs = []
-    for primds, acq_era, min_run, max_run, cmssw, physics_skim, dqm_seq, global_tag in results:
+    for primds, acq_era, min_run, max_run, cmssw, global_tag, physics_skim, dqm_seq in results:
 
         config = { "primary_dataset" : primds,
                    "acq_era" : acq_era,
                    "min_run" : min_run,
                    "max_run" : max_run,
                    "cmssw" : cmssw,
+                   "global_tag" : global_tag,
                    "physics_skim" : physics_skim,
-                   "dqm_seq" : dqm_seq,
-                   "global_tag" : global_tag
+                   "dqm_seq" : dqm_seq
                    }
         configs.append(config)
 

--- a/src/python/DataPrimaryDatasetConfig.py
+++ b/src/python/DataPrimaryDatasetConfig.py
@@ -1,0 +1,61 @@
+from WMCore.REST.Server import RESTEntity, restcall, rows
+from WMCore.REST.Tools import tools
+from WMCore.REST.Validation import *
+from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
+from T0WmaDataSvc.Regexps import *
+from operator import itemgetter
+
+class RecoConfig(RESTEntity):
+  """REST entity for retrieving a specific primary dataset."""
+  def validate(self, apiobj, method, api, param, safe):
+    """Validate request input data."""
+    validate_str('primary_dataset', param, safe, RX_PRIMARY_DATASET, optional = True)
+
+  @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+  @tools.expires(secs=300)
+  def get(self, primary_dataset):
+    """Retrieve Reco configuration and its history for a specific primary dataset
+
+    :arg str primary_dataset: the primary dataset name (optional, otherwise queries for muon 0)
+    :returns: PrimaryDataset, Acquisition era, minimum run, maximum run, CMSSW, PhysicsSkim, DqmSeq, GlobalTag"""
+
+    sql = """
+            SELECT reco_config.primds, run_config.acq_era, MIN(run_config.run) min_run, MAX(run_config.run) max_run, reco_config.cmssw, reco_config.global_tag, reco_config.physics_skim, reco_config.dqm_seq
+            FROM reco_config
+            JOIN run_config ON run_config.run = reco_config.run
+
+            """
+    sql_with_primds = "WHERE primds = :primary_dataset"
+    sql_group = "GROUP BY run_config.acq_era, reco_config.primds, reco_config.cmssw,  reco_config.global_tag, reco_config.physics_skim, reco_config.dqm_seq"
+    sql_order = "ORDER BY MIN(run_config.run) desc, MAX(run_config.run) desc"
+
+    binds = {}
+    if primary_dataset is not None:
+        sql += sql_with_primds
+        binds.update({"primds":primary_dataset})
+    else:
+       binds.update({"primds":'Muon0'})
+       sql += "WHERE primds = 'Muon0'"
+
+    sql += sql_group
+    sql += sql_order
+
+    c, _ = self.api.execute(sql, binds)
+    results=c.fetchall()
+
+  
+    configs = []
+    for primds, acq_era, min_run, max_run, cmssw, physics_skim, dqm_seq, global_tag in results:
+
+        config = { "primary_dataset" : primds,
+                   "acq_era" : acq_era,
+                   "min_run" : min_run,
+                   "max_run" : max_run,
+                   "cmssw" : cmssw,
+                   "physics_skim" : physics_skim,
+                   "dqm_seq" : dqm_seq,
+                   "global_tag" : global_tag
+                   }
+        configs.append(config)
+
+    return configs

--- a/src/python/DataRunStreamSkippedLumis.py
+++ b/src/python/DataRunStreamSkippedLumis.py
@@ -1,0 +1,53 @@
+from WMCore.REST.Server import RESTEntity, restcall, rows
+from WMCore.REST.Tools import tools
+from WMCore.REST.Validation import *
+from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
+from T0WmaDataSvc.Regexps import *
+from operator import itemgetter
+
+class RunStreamSkippedLumis(RESTEntity):
+  """REST entity for retrieving run/stream/lumis that have been skipped during processing."""
+  def validate(self, apiobj, method, api, param, safe):
+    """Validate request input data."""
+    validate_str('run', param, safe, RX_RUN, optional = True)
+    validate_str('stream', param, safe, RX_STREAM, optional = True)
+
+  @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+  @tools.expires(secs=300)
+  def get(self,run, stream):
+    """Retrieve run/stream/lumis that have been skipped during processing. If no run or stream is 
+    specified, returns the latest 100 skipped runs
+
+    :arg int run: the run number
+    :arg str primary_dataset: the primary dataset name (optional, otherwise queries for all)
+    :returns: list of skipped lumis in each run/stream combination, and number of events in the lumi"""
+
+    sql = """SELECT run, stream, lumi, events
+             FROM skipped_streamers
+             WHERE run is not null"""
+    sqlWithRun = " AND skipped_streamers.run = :run"
+    sqlWithStream = " AND skipped_streamers.stream = :stream"
+    sqlOrder = " ORDER BY run desc, stream asc, lumi asc"
+    sqlLimit = " FETCH FIRST 100 ROWS ONLY"
+
+    binds = {}
+    if run is not None:
+        sql += sqlWithRun
+        binds.update({"run":run})
+    if stream is not None:
+        sql += sqlWithStream
+        binds.update({"stream":stream})
+    sql += sqlOrder
+    if run is None:
+        sql += sqlLimit
+
+    c, _ = self.api.execute(sql, binds)
+    results=c.fetchall()
+
+    runs={}
+    for run, stream, lumi, events in results:
+        runDict=runs.setdefault(run,{})
+        streamDict=runDict.setdefault(stream,{})
+        streamDict[lumi]=events
+
+    return [runs]


### PR DESCRIPTION
This API entry was requested in the following Jira ticket: https://its.cern.ch/jira/browse/CMSTZDEV-793?filter=-1

It returns Acquisition era, minimum run, maximum run, CMSSW, PhysicsSkim, DqmSeq, GlobalTag configuration for a given primary dataset. It returns the respective configuration for each time it was changed. In other words, the history of the configuration for that specific primary dataset.

