### PR TITLE
New API Entry with history of primary dataset configuration

### DIFF
--- a/etc/OracleSchema.sql
+++ b/etc/OracleSchema.sql
@@ -1,6 +1,3 @@
-----------------------------------------------------------------------
--- Create tables for Tier0 Data Service Database.
-
 CREATE TABLE express_config (
   run int not null,
   stream varchar2(255) not null,
@@ -79,6 +76,18 @@ CREATE TABLE skipped_streamers (
   lumi int not null,
   events int not null,
   primary key (run, stream, lumi)
+) ORGANIZATION INDEX;
+
+CREATE TABLE primary_dataset_config (
+  primds varchar2(255) not null,
+  acq_era varchar2(255) not null,
+  min_run int not null,
+  max_run int not null,
+  cmssw varchar2(255) not null,
+  global_tag varchar2(50) not null,
+  physics_skim varchar2(700),
+  dqm_seq varchar2(700),
+  primary key (primds)
 ) ORGANIZATION INDEX;
 
 CREATE TABLE FILE_TRANSFER_STATUS_OFFLINE (

--- a/src/python/Data.py
+++ b/src/python/Data.py
@@ -11,7 +11,7 @@ from T0WmaDataSvc.DataPromptRecoStatus import *
 from T0WmaDataSvc.DataDatasetLocked import *
 from T0WmaDataSvc.DataRepackStats import *
 from T0WmaDataSvc.DataRunStreamSkippedLumis import *
-
+from T0WmaDataSvc.DataPrimaryDatasetConfig import *
 
 class Data(DatabaseRESTApi):
   """Server object for REST data access API."""

--- a/src/python/Data.py
+++ b/src/python/Data.py
@@ -34,5 +34,6 @@ class Data(DatabaseRESTApi):
                 "dataset_locked": DatasetLocked(app, self, config, mount),
                 "promptreco_status": PromptRecoStatus(app, self, config, mount),
                 "repack_stats": RepackStats(app, self, config, mount),
-                "skipped_streamers": RunStreamSkippedLumis(app, self, config, mount)
+                "skipped_streamers": RunStreamSkippedLumis(app, self, config, mount),
+                "primary_dataset_config": PrimaryDatasetConfig(app, self, config, mount)
                 })

--- a/src/python/DataPrimaryDatasetConfig.py
+++ b/src/python/DataPrimaryDatasetConfig.py
@@ -1,0 +1,61 @@
+from WMCore.REST.Server import RESTEntity, restcall, rows
+from WMCore.REST.Tools import tools
+from WMCore.REST.Validation import *
+from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
+from T0WmaDataSvc.Regexps import *
+from operator import itemgetter
+
+class RecoConfig(RESTEntity):
+  """REST entity for retrieving a specific primary dataset."""
+  def validate(self, apiobj, method, api, param, safe):
+    """Validate request input data."""
+    validate_str('primary_dataset', param, safe, RX_PRIMARY_DATASET, optional = True)
+
+  @restcall(formats=[('text/plain', PrettyJSONFormat()), ('application/json', JSONFormat())])
+  @tools.expires(secs=300)
+  def get(self, primary_dataset):
+    """Retrieve Reco configuration and its history for a specific primary dataset
+
+    :arg str primary_dataset: the primary dataset name (optional, otherwise queries for muon 0)
+    :returns: PrimaryDataset, Acquisition era, minimum run, maximum run, CMSSW, PhysicsSkim, DqmSeq, GlobalTag"""
+
+    sql = """
+            SELECT reco_config.primds primds, run_config.acq_era acq_era, MIN(run_config.run) min_run, MAX(run_config.run) max_run, reco_config.cmssw cmssw, reco_config.global_tag global_tag, reco_config.physics_skim physics_skim, reco_config.dqm_seq dqm_seq
+            FROM reco_config
+            JOIN run_config ON run_config.run = reco_config.run
+
+            """
+    sql_with_primds = "WHERE primds = :primary_dataset"
+    sql_group = "GROUP BY run_config.acq_era, reco_config.primds, reco_config.cmssw,  reco_config.global_tag, reco_config.physics_skim, reco_config.dqm_seq"
+    sql_order = "ORDER BY MIN(run_config.run) desc, MAX(run_config.run) desc"
+
+    binds = {}
+    if primary_dataset is not None:
+        sql += sql_with_primds
+        binds.update({"primds":primary_dataset})
+    else:
+       binds.update({"primds":'Muon0'})
+       sql += "WHERE primds = 'Muon0'"
+
+    sql += sql_group
+    sql += sql_order
+    sql += "INTO primary_dataset_config"
+    c, _ = self.api.execute(sql, binds)
+    results=c.fetchall()
+
+  
+    configs = []
+    for primds, acq_era, min_run, max_run, cmssw, global_tag, physics_skim, dqm_seq in results:
+
+        config = { "primary_dataset" : primds,
+                   "acq_era" : acq_era,
+                   "min_run" : min_run,
+                   "max_run" : max_run,
+                   "cmssw" : cmssw,
+                   "global_tag" : global_tag,
+                   "physics_skim" : physics_skim,
+                   "dqm_seq" : dqm_seq
+                   }
+        configs.append(config)
+
+    return configs

--- a/src/python/DataPrimaryDatasetConfig.py
+++ b/src/python/DataPrimaryDatasetConfig.py
@@ -5,7 +5,7 @@ from WMCore.REST.Format import JSONFormat, PrettyJSONFormat
 from T0WmaDataSvc.Regexps import *
 from operator import itemgetter
 
-class RecoConfig(RESTEntity):
+class PrimaryDatasetConfig(RESTEntity):
   """REST entity for retrieving a specific primary dataset."""
   def validate(self, apiobj, method, api, param, safe):
     """Validate request input data."""


### PR DESCRIPTION
This API entry was requested in the following Jira ticket: https://its.cern.ch/jira/browse/CMSTZDEV-793?filter=-1

It returns Acquisition era, minimum run, maximum run, CMSSW, PhysicsSkim, DqmSeq, GlobalTag configuration for a given primary dataset. It returns the respective configuration for each time it was changed. In other words, the history of the configuration for that specific primary dataset.