### PR TITLE
Support of era completion of uploading metadata to dbs

### DIFF
--- a/etc/OracleSchema.sql
+++ b/etc/OracleSchema.sql
@@ -81,6 +81,12 @@ CREATE TABLE skipped_streamers (
   primary key (run, stream, lumi)
 ) ORGANIZATION INDEX;
 
+CREATE TABLE dbsbuffer_block (
+  block varchar2(255) not null,
+  acq_era varchar2(255) not null,
+  status varchar2(255) not null
+) ORGANIZATION INDEX;
+
 CREATE TABLE FILE_TRANSFER_STATUS_OFFLINE (
   P5_FILEID               NUMBER(27)     NOT NULL,
   FILENAME                VARCHAR2(1000) NOT NULL,


### PR DESCRIPTION
This PR intends to provide information on wether or not all data for an era is in dbs. The idea is to update the current `era_history` entry point for this.

The corresponding jira ticket is https://its.cern.ch/jira/browse/CMSTZDEV-812?filter=-1

The parallel updates in the T0 repository are in the PR: 